### PR TITLE
Change my link from linkedin to twitter

### DIFF
--- a/2020/README.adoc
+++ b/2020/README.adoc
@@ -16,7 +16,7 @@
 | Open Data Award
 | 
 
-https://www.linkedin.com/in/hairmare/[Lucas Bickel]
+https://twitter.com/hairmare/[Lucas Bickel]
 
 https://www.linkedin.com/in/giammi/[Gian-Maria Daffré]
 


### PR DESCRIPTION
I haven't used linkedin for ages and my profile there is not representative of who I am.

A link to my GitHub profile would also work ;)